### PR TITLE
Add division and remainder instructions for rv32gc

### DIFF
--- a/spec/instruction_exec/div_spec.lua
+++ b/spec/instruction_exec/div_spec.lua
@@ -1,0 +1,47 @@
+local CPU = require("cpu").CPU
+local instructions = require("instruction")
+
+local Instruction = instructions.Instruction
+local getOpcodeAndFuncsForMnemonic = instructions.getOpcodeAndFuncsForMnemonic
+
+local opcode, funct3, funct7 = getOpcodeAndFuncsForMnemonic("div")
+
+describe("div", function()
+    local cpu
+    local instructionData
+
+    before_each(function()
+        cpu = CPU.new()
+        instructionData = {
+            opcode = opcode,
+            funct3 = funct3,
+            funct7 = funct7,
+        }
+    end)
+
+    it("regular", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 3
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(3, cpu.registers[1])
+    end)
+
+    it("division by zero", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 0
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(0xFFFFFFFF, cpu.registers[1])
+    end)
+end)

--- a/spec/instruction_exec/divu_spec.lua
+++ b/spec/instruction_exec/divu_spec.lua
@@ -1,0 +1,47 @@
+local CPU = require("cpu").CPU
+local instructions = require("instruction")
+
+local Instruction = instructions.Instruction
+local getOpcodeAndFuncsForMnemonic = instructions.getOpcodeAndFuncsForMnemonic
+
+local opcode, funct3, funct7 = getOpcodeAndFuncsForMnemonic("divu")
+
+describe("divu", function()
+    local cpu
+    local instructionData
+
+    before_each(function()
+        cpu = CPU.new()
+        instructionData = {
+            opcode = opcode,
+            funct3 = funct3,
+            funct7 = funct7,
+        }
+    end)
+
+    it("regular", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 3
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(3, cpu.registers[1])
+    end)
+
+    it("division by zero", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 0
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(0xFFFFFFFF, cpu.registers[1])
+    end)
+end)

--- a/spec/instruction_exec/rem_spec.lua
+++ b/spec/instruction_exec/rem_spec.lua
@@ -1,0 +1,47 @@
+local CPU = require("cpu").CPU
+local instructions = require("instruction")
+
+local Instruction = instructions.Instruction
+local getOpcodeAndFuncsForMnemonic = instructions.getOpcodeAndFuncsForMnemonic
+
+local opcode, funct3, funct7 = getOpcodeAndFuncsForMnemonic("rem")
+
+describe("rem", function()
+    local cpu
+    local instructionData
+
+    before_each(function()
+        cpu = CPU.new()
+        instructionData = {
+            opcode = opcode,
+            funct3 = funct3,
+            funct7 = funct7,
+        }
+    end)
+
+    it("regular", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 3
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(1, cpu.registers[1])
+    end)
+
+    it("division by zero", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 0
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(10, cpu.registers[1])
+    end)
+end)

--- a/spec/instruction_exec/remu_spec.lua
+++ b/spec/instruction_exec/remu_spec.lua
@@ -1,0 +1,47 @@
+local CPU = require("cpu").CPU
+local instructions = require("instruction")
+
+local Instruction = instructions.Instruction
+local getOpcodeAndFuncsForMnemonic = instructions.getOpcodeAndFuncsForMnemonic
+
+local opcode, funct3, funct7 = getOpcodeAndFuncsForMnemonic("remu")
+
+describe("remu", function()
+    local cpu
+    local instructionData
+
+    before_each(function()
+        cpu = CPU.new()
+        instructionData = {
+            opcode = opcode,
+            funct3 = funct3,
+            funct7 = funct7,
+        }
+    end)
+
+    it("regular", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 3
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(1, cpu.registers[1])
+    end)
+
+    it("division by zero", function()
+        cpu.registers[1] = 10
+        cpu.registers[2] = 0
+        instructionData.rd = 1
+        instructionData.rs1 = 1
+        instructionData.rs2 = 2
+        local inst = Instruction.new(instructionData)
+
+        inst:exec(cpu)
+
+        assert.are.equal(10, cpu.registers[1])
+    end)
+end)

--- a/src/instruction.lua
+++ b/src/instruction.lua
@@ -47,6 +47,22 @@ local INSTRUCTIONS = {
                 exec = function(inst, cpu)
                     cpu:writeReg(inst.rd, cpu.registers[inst.rs1] ~ cpu.registers[inst.rs2])
                 end
+            },
+            [0x1] = {
+                name = "div",
+                exec = function(inst, cpu)
+                    local dividend = numberUtils.i32ToI64(cpu.registers[inst.rs1])
+                    local divisor = numberUtils.i32ToI64(cpu.registers[inst.rs2])
+                    local result
+                    if divisor == 0 then
+                        result = -1
+                    elseif dividend == -0x80000000 and divisor == -1 then
+                        result = -0x80000000
+                    else
+                        result = dividend // divisor
+                    end
+                    cpu:writeReg(inst.rd, result)
+                end
             }
         },
         [0x6] = {
@@ -55,6 +71,21 @@ local INSTRUCTIONS = {
                 exec = function(inst, cpu)
                     cpu:writeReg(inst.rd, cpu.registers[inst.rs1] | cpu.registers[inst.rs2])
                 end
+            },
+            [0x1] = {
+                name = "rem",
+                exec = function(inst, cpu)
+                    local dividend = numberUtils.i32ToI64(cpu.registers[inst.rs1])
+                    local divisor = numberUtils.i32ToI64(cpu.registers[inst.rs2])
+                    local result
+                    if divisor == 0 then
+                        result = dividend
+                    else
+                        local quotient = dividend // divisor
+                        result = dividend - quotient * divisor
+                    end
+                    cpu:writeReg(inst.rd, result)
+                end
             }
         },
         [0x7] = {
@@ -62,6 +93,19 @@ local INSTRUCTIONS = {
                 name = "and",
                 exec = function(inst, cpu)
                     cpu:writeReg(inst.rd, cpu.registers[inst.rs1] & cpu.registers[inst.rs2])
+                end
+            },
+            [0x1] = {
+                name = "remu",
+                exec = function(inst, cpu)
+                    local divisor = cpu.registers[inst.rs2]
+                    local result
+                    if divisor == 0 then
+                        result = cpu.registers[inst.rs1]
+                    else
+                        result = cpu.registers[inst.rs1] % divisor
+                    end
+                    cpu:writeReg(inst.rd, result)
                 end
             }
         },
@@ -94,6 +138,19 @@ local INSTRUCTIONS = {
                 exec = function(inst, cpu)
                     local msb = cpu.registers[inst.rs1] & 0x80000000
                     cpu:writeReg(inst.rd, (cpu.registers[inst.rs1] >> cpu.registers[inst.rs2]) | msb)
+                end
+            },
+            [0x1] = {
+                name = "divu",
+                exec = function(inst, cpu)
+                    local divisor = cpu.registers[inst.rs2]
+                    local result
+                    if divisor == 0 then
+                        result = 0xFFFFFFFF
+                    else
+                        result = cpu.registers[inst.rs1] // divisor
+                    end
+                    cpu:writeReg(inst.rd, result)
                 end
             },
         },


### PR DESCRIPTION
## Summary
- implement `div`, `divu`, `rem`, and `remu` instructions
- add specs for the new arithmetic operations
